### PR TITLE
Automatically get cookies from browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ setup:
 	pre-commit install
 	python scripts/leetcode_tools.py download-client
 
-re-login:
-	python scripts/leetcode_tools.py relogin
+leetcode-login:
+	python scripts/leetcode_tools.py leetcode-login
 
 test-solutions:
 	env PYTHONPATH=src pytest src -s --verbose --cov=src --cov-report=html --cov-report=term-missing --suppress-no-test-exit-code

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ $ make setup
 Currently, the only way to login is logging into chrome/firefox, then running:
 
 ```shell
-$ make re-login
+$ make leetcode-login
 ```
 
-and copying the needed cookies as required.
+This command automatically gets the needed cookies from the browser.
 
 ### Downloading a Question
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 autoimport == 0.7.0
 black == 20.8b1
+browser-cookie3 == 0.12.1
 clize == 4.1.1
 flake8 == 3.8.4
 flake8-bugbear == 20.11.1
@@ -19,3 +20,4 @@ pytest-cov == 2.10.1
 pytest-custom-exit-code == 0.3.0
 pytest-flake8 == 1.0.6
 pytest-mypy == 0.8.0
+requests == 2.25.1

--- a/scripts/leetcode_tools.py
+++ b/scripts/leetcode_tools.py
@@ -185,8 +185,11 @@ def leetcode_login():
     os.system(os.path.join("bin", "dist", "leetcode-cli") + " user -L")
     os.system("mkdir -p " + os.path.join(home_folder, ".lc", "leetcode"))
     print("Make sure to login to leetcode on either chrome or firefox.")
-    userid, leetcode_session, crsftoken = get_leetcode_cookies()
-    if userid and leetcode_session and crsftoken:
+    try:
+        userid, leetcode_session, crsftoken = get_leetcode_cookies()
+    except ValueError as e:
+        print(e.args)
+    else:
         with open(os.path.join(home_folder, ".lc", "leetcode", "user.json"), "w") as f:
             f.write("{\n")
             f.write(f'    "login": "{userid}",\n')

--- a/scripts/leetcode_tools.py
+++ b/scripts/leetcode_tools.py
@@ -189,10 +189,10 @@ def leetcode_login():
     if userid and leetcode_session and crsftoken:
         with open(os.path.join(home_folder, ".lc", "leetcode", "user.json"), "w") as f:
             f.write("{\n")
-            f.write('\t"login": "' + userid + '",\n')
-            f.write('\t"loginCSRF": "",\n')
-            f.write('\t"sessionCSRF": "' + crsftoken + '",\n')
-            f.write('\t"sessionId": "' + leetcode_session + '"\n')
+            f.write(f'    "login": "{userid}",\n')
+            f.write('    "loginCSRF": "",\n')
+            f.write(f'    "sessionCSRF": "{crsftoken}",\n')
+            f.write(f'    "sessionId": "{leetcode_session}"\n')
             f.write("}")
         os.system(os.path.join("bin", "dist", "leetcode-cli") + " user -c")
         print(f"Logged in as {userid}")

--- a/scripts/leetcode_tools.py
+++ b/scripts/leetcode_tools.py
@@ -20,6 +20,7 @@ from utils import (
     create_folder_if_needed,
     download_leetcode_cli,
     get_file_name,
+    get_leetcode_cookies,
     leetcode_cli_exists,
 )
 
@@ -178,26 +179,24 @@ def download_client():
         download_leetcode_cli()
 
 
-def relogin():
+def leetcode_login():
     home_folder = str(Path.home())
     # Logout. This erases the user.json file
     os.system(os.path.join("bin", "dist", "leetcode-cli") + " user -L")
     os.system("mkdir -p " + os.path.join(home_folder, ".lc", "leetcode"))
-    print("Please insert your leetcode user ID:")
-    userid = str(input())
-    print("Please insert your crsftoken:")
-    crsftoken = str(input())
-    print("Please insert your LEETCODE_SESSION:")
-    leetcode_session = str(input())
-    with open(os.path.join(home_folder, ".lc", "leetcode", "user.json"), "w") as f:
-        f.write("{\n")
-        f.write('\t"login": "' + userid + '",\n')
-        f.write('\t"loginCSRF": "",\n')
-        f.write('\t"sessionCSRF": "' + crsftoken + '",\n')
-        f.write('\t"sessionId": "' + leetcode_session + '"\n')
-        f.write("}")
-    os.system(os.path.join("bin", "dist", "leetcode-cli") + " user -c")
+    print("Make sure to login to leetcode on either chrome or firefox.")
+    userid, leetcode_session, crsftoken = get_leetcode_cookies()
+    if userid and leetcode_session and crsftoken:
+        with open(os.path.join(home_folder, ".lc", "leetcode", "user.json"), "w") as f:
+            f.write("{\n")
+            f.write('\t"login": "' + userid + '",\n')
+            f.write('\t"loginCSRF": "",\n')
+            f.write('\t"sessionCSRF": "' + crsftoken + '",\n')
+            f.write('\t"sessionId": "' + leetcode_session + '"\n')
+            f.write("}")
+        os.system(os.path.join("bin", "dist", "leetcode-cli") + " user -c")
+        print(f"Logged in as {userid}")
 
 
 if __name__ == "__main__":
-    clize.run(get_question, submit_question, download_client, relogin)
+    clize.run(get_question, submit_question, download_client, leetcode_login)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -78,9 +78,9 @@ def get_leetcode_cookies():
             break
 
     if not leetcode_session or not csrftoken or not username:
-        os.error(
-            "ERROR: Could not find the cookies neither on Chrome nor Firefox.\n"
-            + "Make sure to login to leetcode in one of these browsers"
+        raise ValueError(
+            "ERROR: Could not find the cookies neither on Chrome nor Firefox."
+            + " Make sure to login to leetcode in one of these browsers."
         )
 
     return username[0], leetcode_session[0], csrftoken[0]

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -53,3 +53,34 @@ def download_leetcode_cli():
     )
     os.system("tar -xvzf bin/leetcode-cli.node10.linux.x64.tar.gz -C bin")
     os.system("rm bin/leetcode-cli.node10.linux.x64.tar.gz")
+
+
+def get_leetcode_cookies():
+    import re
+
+    import browser_cookie3
+    import requests
+
+    url = "https://leetcode.com/profile/"
+    leetcode_session = []
+    csrftoken = []
+    username = []
+    browsers = (browser_cookie3.chrome(), browser_cookie3.firefox())
+    for browser in browsers:
+        r = requests.get(url, cookies=browser)
+        cookies = r.request.headers["Cookie"]
+        leetcode_session = re.findall(
+            r"LEETCODE_SESSION=(.*?);|$", cookies, flags=re.DOTALL
+        )
+        csrftoken = re.findall(r"csrftoken=(.*?)$|$", cookies, flags=re.DOTALL)
+        username = re.findall(r"username: '(.*?)',", r.text, flags=re.DOTALL)
+        if leetcode_session and csrftoken and username:
+            break
+
+    if not leetcode_session or not csrftoken or not username:
+        os.error(
+            "ERROR: Could not find the cookies neither on Chrome nor Firefox.\n"
+            + "Make sure to login to leetcode in one of these browsers"
+        )
+
+    return username[0], leetcode_session[0], csrftoken[0]


### PR DESCRIPTION
This PR automates the login process by getting the necessary cookies from either chrome or firefox.

Now the user only needs to login to leetcode in one of those browsers and run "make leetcode-login"