### PR TITLE
fix script moving test imports

### DIFF
--- a/scripts/leetcode_tools.py
+++ b/scripts/leetcode_tools.py
@@ -155,11 +155,6 @@ def get_question(id: int):
                 + "\n"
             )
 
-    with open(
-        os.path.join("src", f"{folder}_problems", f"test_{folder}.py"), "r+"
-    ) as f:
-        fix_files([f])
-
     # update readme
     with open("README.md", "r+") as f:
         for line in f:


### PR DESCRIPTION
Currently, the auto-import script will move all test imports to the beginning of the file.

This PR fixes this issue by not running the auto-import script on test files. (as it is not needed)