### PR TITLE
remove linters and snake case

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,0 @@
-[flake8]
-max-line-length = 104
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-ignore = E203, E226, E266, E501, W503, C901
-per-file-ignores = __init__.py:F401

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,6 +18,3 @@ jobs:
     - name: Format with black and isort
       shell: bash -l {0}
       run: make format
-    - name: Lint with pylint, mypy and flake8
-      shell: bash -l {0}
-      run: make lint

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,2 +1,0 @@
-[mypy]
-strict_optional = False

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,3 @@ repos:
     language: system
     entry: make format
     types: [python]
-  - id: lint
-    name: lint
-    language: system
-    entry: make lint
-    types: [python]

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,6 @@ get-question:
 	python scripts/leetcode_tools.py get-question $(ID)
 	make format
 
-lint:
-	env PYTHONPATH=src pytest src --flake8 --mypy
-
 setup:
 	python -m pip install -r requirements.txt
 	pre-commit install

--- a/scripts/leetcode_tools.py
+++ b/scripts/leetcode_tools.py
@@ -17,10 +17,10 @@ from typing import List
 import clize
 from autoimport import fix_files
 from utils import (
-    cammel_to_snake_case,
     create_folder_if_needed,
     download_leetcode_cli,
     get_file_name,
+    get_function_name,
     get_leetcode_cookies,
     leetcode_cli_exists,
 )
@@ -76,7 +76,7 @@ def get_question(id: int):
             if line:
                 data.code.append(line)
 
-    data.code[-1], data.function_name = cammel_to_snake_case(data.code[-1])
+    data.code[-1], data.function_name = get_function_name(data.code[-1])
 
     print("Please, choose the folder to save the problem: ")
     folder = input()

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -4,7 +4,7 @@ import re
 from typing import Tuple
 
 
-def cammel_to_snake_case(func_str: str) -> Tuple[str, str]:
+def get_function_name(func_str: str) -> Tuple[str, str]:
     ret = ""
     func_name = ""
     for i, c in enumerate(func_str):
@@ -12,10 +12,7 @@ def cammel_to_snake_case(func_str: str) -> Tuple[str, str]:
             func_name = ret.split()[-1]
             ret += func_str[i:]
             break
-        if c.isupper():
-            ret += "_" + c.lower()
-        else:
-            ret += c
+        ret += c
     return ret, func_name
 
 


### PR DESCRIPTION
Closes #9 

I have plans to support other languages in the future, so keeping the linters would have a large cost. Leetcode uses camelCase, so this PR also changes the function names from snake_case to camelCase.