### PR TITLE
removing tmp file when getting question method raise ValueError

### DIFF
--- a/scripts/file_handler.py
+++ b/scripts/file_handler.py
@@ -1,3 +1,4 @@
+import os
 import signal
 from abc import ABC, abstractmethod
 from typing import Dict, Type, TypeVar
@@ -50,6 +51,7 @@ def generate_files(
         )
     except ValueError as e:
         print(e.args)
+        os.remove(f"tmp{qid}.txt")
         signal.signal(signal.SIGINT, s)
         return
 


### PR DESCRIPTION
Signed-off-by: sungho <sungho.joo@makinarocks.ai>

When an error occurs while running getting-question method, 'tmp{id}.txt' file remained.

This PR removes tmp file when the process asserts with ValueError.